### PR TITLE
Update to python3 and remove api key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/tcia-rest-client-python/src/sample.py
+++ b/tcia-rest-client-python/src/sample.py
@@ -10,8 +10,8 @@ def printServerResponse(response):
         print("Error: " + str(response.getcode()))
 
 ####################################  Create Clients for Two Different Resources  ####
-tcia_client = TCIAClient(apiKey = "YOUR API KEY HERE",baseUrl="https://services.cancerimagingarchive.net/services/v3",resource = "TCIA")
-tcia_client2 = TCIAClient(apiKey ="YOUR API KEY HERE",baseUrl="https://services.cancerimagingarchive.net/services/v3",resource="SharedList")
+tcia_client = TCIAClient(apiKey = "YOUR API KEY HERE",baseUrl="https://services.cancerimagingarchive.net/services/v4",resource = "TCIA")
+tcia_client2 = TCIAClient(apiKey ="YOUR API KEY HERE",baseUrl="https://services.cancerimagingarchive.net/services/v4",resource="SharedList")
 
 # Test content_by_name
 try:

--- a/tcia-rest-client-python/src/sample.py
+++ b/tcia-rest-client-python/src/sample.py
@@ -10,8 +10,8 @@ def printServerResponse(response):
         print("Error: " + str(response.getcode()))
 
 ####################################  Create Clients for Two Different Resources  ####
-tcia_client = TCIAClient(apiKey = "YOUR API KEY HERE",baseUrl="https://services.cancerimagingarchive.net/services/v4",resource = "TCIA")
-tcia_client2 = TCIAClient(apiKey ="YOUR API KEY HERE",baseUrl="https://services.cancerimagingarchive.net/services/v4",resource="SharedList")
+tcia_client = TCIAClient(baseUrl="https://services.cancerimagingarchive.net/services/v4",resource = "TCIA")
+tcia_client2 = TCIAClient(baseUrl="https://services.cancerimagingarchive.net/services/v4",resource="SharedList")
 
 # Test content_by_name
 try:

--- a/tcia-rest-client-python/src/sample.py
+++ b/tcia-rest-client-python/src/sample.py
@@ -1,13 +1,13 @@
 from tciaclient import TCIAClient
-import urllib2, urllib,sys
+import urllib.request, urllib.error, urllib.parse, urllib.request, urllib.parse, urllib.error,sys
 ####################################  Function to print server response #######
 def printServerResponse(response):
     if response.getcode() == 200:
-        print "Server Returned:\n"
-        print response.read()
-        print "\n"
+        print("Server Returned:\n")
+        print(response.read())
+        print("\n")
     else:
-        print "Error: " + str(response.getcode())
+        print("Error: " + str(response.getcode()))
 
 ####################################  Create Clients for Two Different Resources  ####
 tcia_client = TCIAClient(apiKey = "YOUR API KEY HERE",baseUrl="https://services.cancerimagingarchive.net/services/v3",resource = "TCIA")
@@ -17,8 +17,8 @@ tcia_client2 = TCIAClient(apiKey ="YOUR API KEY HERE",baseUrl="https://services.
 try:
     response = tcia_client2.contents_by_name(name = "sharedListApiUnitTest")
     printServerResponse(response);
-except urllib2.HTTPError, err:
-    print "Errror executing program:\nError Code: ", str(err.code), "\nMessage:", err.read()
+except urllib.error.HTTPError as err:
+    print("Errror executing program:\nError Code: ", str(err.code), "\nMessage:", err.read())
 
 # Test get_manufacturer_values no query parameters
 try:
@@ -28,23 +28,23 @@ try:
                                                    None,outputFormat = "json")
     printServerResponse(response);
 
-except urllib2.HTTPError, err:
-    print "Errror executing program:\nError Code: ", str(err.code), "\nMessage:", err.read()
+except urllib.error.HTTPError as err:
+    print("Errror executing program:\nError Code: ", str(err.code), "\nMessage:", err.read())
 
 # Test get_series_size
 try:
     response = tcia_client.get_series_size(SeriesInstanceUID="1.3.6.1.4.1.14519.5.2.1.7695.4001.306204232344341694648035234440")
     printServerResponse(response);
-except urllib2.HTTPError, err:
-    print "Errror executing program:\nError Code: ", str(err.code), "\nMessage:", err.read()
+except urllib.error.HTTPError as err:
+    print("Errror executing program:\nError Code: ", str(err.code), "\nMessage:", err.read())
 
 # Test get_manufacturer_values with query Parameter
 try:
     response = tcia_client.get_manufacturer_values(collection = "TCGA-GBM",bodyPartExamined = None,modality = None, outputFormat = "csv")
     printServerResponse(response);
 
-except urllib2.HTTPError, err:
-    print "Errror executing program:\nError Code: ", str(err.code), "\nMessage:", err.read()
+except urllib.error.HTTPError as err:
+    print("Errror executing program:\nError Code: ", str(err.code), "\nMessage:", err.read())
 
 # Test get_image.
 # NOTE: Image response consumed differently

--- a/tcia-rest-client-python/src/tciaclient.py
+++ b/tcia-rest-client-python/src/tciaclient.py
@@ -18,16 +18,14 @@ class TCIAClient:
     GET_SERIES_SIZE = "getSeriesSize"
     CONTENTS_BY_NAME = "ContentsByName"
 
-    def __init__(self, apiKey , baseUrl, resource):
-        self.apiKey = apiKey
+    def __init__(self, baseUrl, resource):
         self.baseUrl = baseUrl + "/" + resource
 
     def execute(self, url, queryParameters={}):
         queryParameters = dict((k, v) for k, v in queryParameters.items() if v)
-        headers = {"api_key" : self.apiKey }
         queryString = "?%s" % urllib.parse.urlencode(queryParameters)
         requestUrl = url + queryString
-        request = urllib.request.Request(url=requestUrl , headers=headers)
+        request = urllib.request.Request(url=requestUrl)
         resp = urllib.request.urlopen(request)
         return resp
 

--- a/tcia-rest-client-python/src/tciaclient.py
+++ b/tcia-rest-client-python/src/tciaclient.py
@@ -1,6 +1,6 @@
 import os
-import urllib2
-import urllib
+import urllib.request, urllib.error, urllib.parse
+import urllib.request, urllib.parse, urllib.error
 import sys
 import math
 #
@@ -23,12 +23,12 @@ class TCIAClient:
         self.baseUrl = baseUrl + "/" + resource
 
     def execute(self, url, queryParameters={}):
-        queryParameters = dict((k, v) for k, v in queryParameters.iteritems() if v)
+        queryParameters = dict((k, v) for k, v in queryParameters.items() if v)
         headers = {"api_key" : self.apiKey }
-        queryString = "?%s" % urllib.urlencode(queryParameters)
+        queryString = "?%s" % urllib.parse.urlencode(queryParameters)
         requestUrl = url + queryString
-        request = urllib2.Request(url=requestUrl , headers=headers)
-        resp = urllib2.urlopen(request)
+        request = urllib.request.Request(url=requestUrl , headers=headers)
+        resp = urllib.request.urlopen(request)
         return resp
 
     def get_modality_values(self,collection = None , bodyPartExamined = None , modality = None , outputFormat = "json" ):
@@ -47,7 +47,7 @@ class TCIAClient:
     def contents_by_name(self, name = None):
         serviceUrl = self.baseUrl + "/query/" + self.CONTENTS_BY_NAME
         queryParameters = {"name" : name}
-        print serviceUrl
+        print(serviceUrl)
         resp = self.execute(serviceUrl,queryParameters)
         return resp
 
@@ -90,7 +90,7 @@ class TCIAClient:
     def get_image(self , seriesInstanceUid , downloadPath, zipFileName):
         serviceUrl = self.baseUrl + "/query/" + self.GET_IMAGE
         queryParameters = { "SeriesInstanceUID" : seriesInstanceUid }
-        os.umask(0002)
+        os.umask(0o002)
         try:
             file = os.path.join(downloadPath, zipFileName)
             resp = self.execute( serviceUrl , queryParameters)
@@ -102,11 +102,11 @@ class TCIAClient:
                     downloaded += len(chunk)
                     if not chunk: break
                     fp.write(chunk)
-        except urllib2.HTTPError, e:
-            print "HTTP Error:",e.code , serviceUrl
+        except urllib.error.HTTPError as e:
+            print("HTTP Error:",e.code , serviceUrl)
             return False
-        except urllib2.URLError, e:
-            print "URL Error:",e.reason , serviceUrl
+        except urllib.error.URLError as e:
+            print("URL Error:",e.reason , serviceUrl)
             return False
 
         return True


### PR DESCRIPTION
Updated the Python SDK to use Python 3 since Python 2 is deprecated. 

Changed the URL in the Python SDK to point to v4 of the API.

Removed all references to API key since that was removed in v4 of the API.

Did not change any functionality. 